### PR TITLE
dev-implement time of day precision

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,30 @@
+
+
+
+
+function isEventPassed(currTime, possibleTimes) {
+    for (let element = 0; element < possibleTimes.length; element++) {
+        if (parseInt(possibleTimes[element]) == 0) {
+            possibleTimes[element] = "5";
+        } if (parseInt(possibleTimes[element]) == 1) {
+            possibleTimes[element] = "11";
+        } if (parseInt(possibleTimes[element]) == 2) {
+            possibleTimes[element] = "17";
+        } if (parseInt(possibleTimes[element]) == 3) {
+            possibleTimes[element] = "23";
+
+        }
+    }
+    for (let index = 0; index < possibleTimes.length; index++) {
+        returnTime = -1
+        if (parseInt(currTime.format('k')) < parseInt(possibleTimes[index])) {
+            returnTime = possibleTimes[index];
+            break;
+        }
+    }
+    return returnTime;
+}
+
+module.exports = {
+    isEventPassed
+}

--- a/index.js
+++ b/index.js
@@ -3,13 +3,14 @@ var getEvents = require('./getEvents.js');
 const createEmbeddedMessages = require('./createEmbeds.js');
 const editFunctions = require('./editFunctions.js');
 const Discord = require('discord.js');
+const dayjs = require('dayjs');
 const client = new Discord.Client();
 const prefix = '!';
-const TOKEN = process.env.TOKEN;
+// const TOKEN = process.env.TOKEN;
 const TESTTOKEN = process.env.TESTTOKEN;
 
 
-client.login(TOKEN);
+client.login(TESTTOKEN);
 
 client.once('ready', () => {
   console.info(`Logged in as ${client.user.tag}!`);
@@ -17,7 +18,7 @@ client.once('ready', () => {
 
 client.on('message', message => {
   if (!message.content.startsWith(prefix) || message.author.bot) return;
-
+   currDayAndTime = dayjs(message.createdTimestamp); 
   const args = message.content.slice(prefix.length).trim().split(/ +/);
   const command = args.shift().toLowerCase();
  
@@ -26,7 +27,7 @@ client.on('message', message => {
     if (!args0.length) {
       return message.channel.send(`You did not provide any command arguments`)
     } else if (args0 === 'today') {
-      var event = getEvents.getEventsEntireDay();
+      var event = getEvents.getEventsEntireDay(currDayAndTime);
       embed = createEmbeddedMessages.createDayScheduleEmbed(event);
       if (embed != null) {
         return message.channel.send(embed);
@@ -36,7 +37,7 @@ client.on('message', message => {
     } else if (args0 === 'next') {
       args.shift(); // remove next command from str arr
       var stringArgument = editFunctions.ArgumentToString(args); //convert arr to str
-      var returnMessage = getEvents.getNextEvent(stringArgument); //
+      var returnMessage = getEvents.getNextEvent(stringArgument, currDayAndTime); //
       if (returnMessage != null) {
         return message.channel.send(returnMessage);
       } else {
@@ -46,7 +47,7 @@ client.on('message', message => {
     } else if (args0 === 'list') {
       args.shift(); // remove next command from str arr
       var stringArgument = editFunctions.ArgumentToString(args); //convert arr to str
-      var returnMessage = getEvents.getListOfEvent(stringArgument); //
+      var returnMessage = getEvents.getListOfEvent(stringArgument, currDayAndTime) //
       if (returnMessage != null) {
         return message.channel.send(returnMessage);
       } else {

--- a/index.js
+++ b/index.js
@@ -6,11 +6,11 @@ const Discord = require('discord.js');
 const dayjs = require('dayjs');
 const client = new Discord.Client();
 const prefix = '!';
-// const TOKEN = process.env.TOKEN;
+const TOKEN = process.env.TOKEN;
 const TESTTOKEN = process.env.TESTTOKEN;
 
 
-client.login(TESTTOKEN);
+client.login(TOKEN);
 
 client.once('ready', () => {
   console.info(`Logged in as ${client.user.tag}!`);


### PR DESCRIPTION
Changed so that the time will now be taken from the timestamp of the message that sent the query. Previously it was taken from a new date object created at the time of query. This change was made to be able to know what hour of the day the message was sent.
Created helpers.js for helper functions and implemented a function that checks if the current time of day is past the time of the next event found. 

Fixed so that the bot is now more precise. If the next 'event' is on the same day as the message is sent on it will now check if the event has already been or if it upcoming. If the event was before the message has been sent it will find the next event. 

If there are multiple events a day it will now show the correct event as the next event. It previously only showed the first regardless of time of day. 
![image](https://user-images.githubusercontent.com/45630121/107087093-39da6b80-67fb-11eb-8a8a-0c7caf6759d1.png)

![image](https://user-images.githubusercontent.com/45630121/107087334-99387b80-67fb-11eb-9075-6d052d1abde7.png)
